### PR TITLE
fix(employee): add property setters for bank and bank_name

### DIFF
--- a/victoryfarmsdeveloper/fixtures/property_setter.json
+++ b/victoryfarmsdeveloper/fixtures/property_setter.json
@@ -1,0 +1,47 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Employee",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "bank",
+  "modified": "2026-07-07 00:00:00.000000",
+  "module": "VictoryFarmsDeveloper",
+  "name": "Employee-bank-reqd",
+  "property": "reqd",
+  "property_type": "Check",
+  "row_name": null,
+  "value": "0"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Employee",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "bank_name",
+  "modified": "2026-07-07 00:00:00.000000",
+  "module": "VictoryFarmsDeveloper",
+  "name": "Employee-bank_name-fieldtype",
+  "property": "fieldtype",
+  "property_type": "Select",
+  "row_name": null,
+  "value": "Select"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Employee",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "bank_name",
+  "modified": "2026-07-07 00:00:00.000000",
+  "module": "VictoryFarmsDeveloper",
+  "name": "Employee-bank_name-options",
+  "property": "options",
+  "property_type": "Text",
+  "row_name": null,
+  "value": ""
+ }
+]

--- a/victoryfarmsdeveloper/hooks.py
+++ b/victoryfarmsdeveloper/hooks.py
@@ -11,9 +11,11 @@ fixtures = [
     "Client Script",
     "Server Script",
     "Custom Field",
+    "Property Setter",
     {"dt": "Client Script", "filters": [["module", "like", "VictoryFarmsDeveloper"]]},
     {"dt": "Server Script", "filters": [["module", "like", "VictoryFarmsDeveloper"]]},
     {"dt": "Custom Field", "filters": [["module", "like", "VictoryFarmsDeveloper"]]},
+    {"dt": "Property Setter", "filters": [["module", "like", "VictoryFarmsDeveloper"]]},
 ]
 
 


### PR DESCRIPTION
- Ensure Bank field is not required via Property Setter
- Change bank_name fieldtype from Data to Select so dropdown options work
- Populate bank_name options from Bank doctype in client script
- Export Property Setter fixtures